### PR TITLE
#1 fix script error handling by using shell sets; replace if brackets

### DIFF
--- a/resources/usr/bin/create_truststore.sh
+++ b/resources/usr/bin/create_truststore.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
 
 DIRECTORY="/etc/ssl"
 STORE="${1:-$DIRECTORY/truststore.jks}"
@@ -7,7 +10,7 @@ CERTALIAS="ces"
 
 function create(){
   # create ssl directory
-  if [ ! -d "$DIRECTORY" ]; then
+  if [[ ! -d "$DIRECTORY" ]]; then
     mkdir "$DIRECTORY"
   fi
 


### PR DESCRIPTION
The shell script did not react in any way towards any occurred errors.
This commit adds the usual bash handling: If any command or pipe fails
the whole script returns with an exit code != zero, indicating there was
an error.

Furthermore, single brackets in bash scripts are discouraged. For more
if-test safety one occurrence was replaced with double brackets which
is supposed to have
[less surprises](https://stackoverflow.com/questions/669452/).

resolves #1 