### PR TITLE
Fix shell unit test failures and build environment configuration

### DIFF
--- a/resources/usr/bin/create_truststore.sh
+++ b/resources/usr/bin/create_truststore.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DIRECTORY="/etc/ssl"
+DIRECTORY="${DIRECTORY:-/etc/ssl}"
 STORE=""
 STOREPASS="changeit"
 CERTALIAS="ces"

--- a/unitTests/create_truststore.bats
+++ b/unitTests/create_truststore.bats
@@ -11,18 +11,24 @@ load '/workspace/target/bats_libs/bats-file/load.bash'
 setup() {
   export STARTUP_DIR=/workspace/
 
+  export MOCK_SSL_DIR="${BATS_TMPDIR}/etc/ssl"
+  mkdir -p "${MOCK_SSL_DIR}/certs/java"
+  echo "mock-base-cacerts" > "${MOCK_SSL_DIR}/certs/java/cacerts"
+  export DIRECTORY="${MOCK_SSL_DIR}"
+
   # bats-mock/mock_create needs to be injected into the path so the production code will find the mock
   doguctl="$(mock_create)"
   export doguctl
   ln -s "${doguctl}" "${BATS_TMPDIR}/doguctl"
+
   keytool="$(mock_create)"
   export keytool
-  export PATH="${PATH}:${BATS_TMPDIR}"
+  export PATH="${BATS_TMPDIR}:${PATH}"
   ln -s "${keytool}" "${BATS_TMPDIR}/keytool"
   mockTruststore="$(mktemp)"
   export mockTruststore
-  BATSLIB_FILE_PATH_REM="#${TEST_TEMP_DIR}"
-  BATSLIB_FILE_PATH_ADD='<temp>'
+  export BATSLIB_FILE_PATH_REM="${BATS_TMPDIR}"
+  export BATSLIB_FILE_PATH_ADD='<temp>'
 }
 
 teardown() {


### PR DESCRIPTION
- Allow overwriting of `DIRECTORY`
- Update `setup()` to create mock preventing `cp` cmd failure
- Adjust `PATH` to prepend tmp dir, ensuring mocked binaries are called before system ones
- Export `BATSLIB_FILE_PATH_REM` and `BATSLIB_FILE_PATH_ADD`